### PR TITLE
Add custom help messages.

### DIFF
--- a/prep/src/cmd/clippy.rs
+++ b/prep/src/cmd/clippy.rs
@@ -5,14 +5,14 @@ use std::process::Command;
 
 use anyhow::{Context, ensure};
 
-use crate::ui::print_cmd;
+use crate::ui;
 
 /// Runs Clippy analysis
 pub fn run() -> anyhow::Result<()> {
     let mut cmd = Command::new("cargo");
     let cmd = cmd.arg("clippy").arg("--workspace").arg("--all-features");
 
-    print_cmd(cmd);
+    ui::print_cmd(cmd);
 
     let status = cmd.status().context("failed to run cargo clippy")?;
     ensure!(status.success(), "cargo clippy failed: {status}");

--- a/prep/src/cmd/format.rs
+++ b/prep/src/cmd/format.rs
@@ -5,14 +5,14 @@ use std::process::Command;
 
 use anyhow::{Context, ensure};
 
-use crate::ui::print_cmd;
+use crate::ui;
 
 /// Format the workspace
 pub fn run() -> anyhow::Result<()> {
     let mut cmd = Command::new("cargo");
     let cmd = cmd.arg("fmt").arg("--all");
 
-    print_cmd(cmd);
+    ui::print_cmd(cmd);
 
     let status = cmd.status().context("failed to run cargo fmt")?;
     ensure!(status.success(), "cargo fmt failed: {status}");

--- a/prep/src/main.rs
+++ b/prep/src/main.rs
@@ -6,7 +6,9 @@
 mod cmd;
 mod ui;
 
-use clap::{CommandFactory, Parser, Subcommand};
+use clap::{CommandFactory, FromArgMatches, Parser, Subcommand};
+
+use ui::help;
 
 #[derive(Parser)]
 #[command(version, about, long_about = None)]
@@ -17,17 +19,19 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Commands {
-    /// Clippy analysis
+    #[command(alias = "clp")]
     Clippy,
-    /// Format files
+    #[command(alias = "fmt")]
     Format,
 }
 
 fn main() -> anyhow::Result<()> {
-    let cli = Cli::parse();
+    let ccmd = help::set(Cli::command());
+    let matches = ccmd.get_matches();
+    let cli = Cli::from_arg_matches(&matches).unwrap();
 
     let Some(command) = cli.command else {
-        Cli::command().print_help().unwrap();
+        ui::print_help();
         return Ok(());
     };
 

--- a/prep/src/ui/help.rs
+++ b/prep/src/ui/help.rs
@@ -1,0 +1,99 @@
+// Copyright 2026 the Prep Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use clap::Command;
+use clap::builder::StyledStr;
+use clap::builder::styling::{Color, Style};
+
+/// Sets our custom help messages.
+pub fn set(cmd: Command) -> Command {
+    let cmd = cmd.override_help(root_msg());
+
+    cmd.mut_subcommands(|mut scmd| {
+        let name = scmd.get_name();
+        if name == "format" {
+            scmd = scmd.override_help(format_msg());
+        } else if name == "clippy" {
+            scmd = scmd.override_help(clippy_msg());
+        } else {
+            panic!("Sub-command '{name}' help message is not implemented");
+        }
+        scmd
+    })
+}
+
+fn color(index: u8) -> Option<Color> {
+    Some(Color::Ansi256(index.into()))
+}
+
+/// Returns `(header, cmd_or_arg, optional)` styles.
+///
+/// These correspond to `(green, cyan, blue)`.
+fn styles() -> (Style, Style, Style) {
+    let g = Style::new().fg_color(color(10)); // Green
+    let c = Style::new().fg_color(color(14)); // Cyan
+    let b = Style::new().fg_color(color(39)); // Blue
+    (g, c, b)
+}
+
+/// Returns the main help message.
+pub fn root_msg() -> StyledStr {
+    let (gb, cb, bb) = styles();
+    let help = format!(
+        "\
+Prepare Rust projects for greatness.
+
+{gb}Usage:{gb:#} {cb}prep{cb:#} {bb}[command] [options]{bb:#}
+
+{gb}Commands:{gb:#}
+  {cb}clp  clippy    {cb:#}Clippy analysis
+  {cb}fmt  format    {cb:#}Format files
+  {cb}     help      {cb:#}Print help
+
+{gb}Options:{gb:#}
+  {cb}-h  --help     {cb:#}Print help
+  {cb}-V  --version  {cb:#}Print version
+"
+    );
+
+    StyledStr::from(help)
+}
+
+/// Returns the `format` help message.
+fn format_msg() -> StyledStr {
+    let (gb, cb, bb) = styles();
+
+    let help = format!(
+        "\
+Format the Rust workspace with rustfmt.
+
+{gb}Usage:{gb:#} {cb}prep fmt{cb:#}    {bb}[options]{bb:#}
+····      ······ {cb}prep format{cb:#} {bb}[options]{bb:#}
+
+{gb}Options:{gb:#}
+  {cb}-h  --help     {cb:#}Print help
+"
+    )
+    .replace("·", "");
+
+    StyledStr::from(help)
+}
+
+/// Returns the `clippy` help message.
+fn clippy_msg() -> StyledStr {
+    let (gb, cb, bb) = styles();
+    let help = format!(
+        "\
+Analyze the Rust workspace with Clippy.
+
+{gb}Usage:{gb:#} {cb}prep clp{cb:#}    {bb}[options]{bb:#}
+····      ······ {cb}prep clippy{cb:#} {bb}[options]{bb:#}
+
+{gb}Options:{gb:#}
+  {cb}-h  --help     {cb:#}Print help
+"
+    )
+    .replace("·", "");
+
+    StyledStr::from(help)
+}

--- a/prep/src/ui/mod.rs
+++ b/prep/src/ui/mod.rs
@@ -1,6 +1,8 @@
 // Copyright 2026 the Prep Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+pub mod help;
+
 use std::ffi::OsStr;
 use std::process::Command;
 
@@ -10,4 +12,9 @@ pub fn print_cmd(cmd: &Command) {
     let args = cmd.get_args().collect::<Vec<_>>().join(OsStr::new(" "));
 
     eprintln!("     Running `{} {}`", bin.display(), args.display());
+}
+
+pub fn print_help() {
+    // TODO: Don't print ANSI codes when not supported by the environment.
+    eprint!("{}", help::root_msg().ansi());
 }


### PR DESCRIPTION
The default `clap` help messages are quite limiting. Better to do it ourselves as then we get full control over structure and styling.