### PR TITLE
Add `ci` command.

### DIFF
--- a/prep/src/cmd/ci.rs
+++ b/prep/src/cmd/ci.rs
@@ -1,0 +1,35 @@
+// Copyright 2026 the Prep Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use crate::cmd::{clippy, format};
+
+/// Runs CI verification.
+///
+/// Can be ran in `extended` mode for more thorough checks.
+///
+/// Set `fail_fast` to `false` to run the checks to the end regardless of failure.
+pub fn run(_extended: bool, fail_fast: bool) -> anyhow::Result<()> {
+    let mut errs: Vec<anyhow::Error> = Vec::new();
+    let mut step = |f: fn() -> anyhow::Result<()>| -> anyhow::Result<()> {
+        if let Err(e) = f() {
+            if fail_fast {
+                return Err(e);
+            }
+            errs.push(e);
+        }
+        Ok(())
+    };
+
+    step(|| format::run(true))?;
+    step(|| clippy::run(true))?;
+
+    if errs.is_empty() {
+        Ok(())
+    } else {
+        let mut msg = String::from("CI verification failed:\n");
+        for (i, e) in errs.into_iter().enumerate() {
+            msg.push_str(&format!("{}: {:#}\n", i + 1, e));
+        }
+        Err(anyhow::anyhow!(msg))
+    }
+}

--- a/prep/src/cmd/clippy.rs
+++ b/prep/src/cmd/clippy.rs
@@ -7,10 +7,15 @@ use anyhow::{Context, ensure};
 
 use crate::ui;
 
-/// Runs Clippy analysis
-pub fn run() -> anyhow::Result<()> {
+/// Runs Clippy analysis.
+///
+/// In `strict` mode warnings are treated as errors.
+pub fn run(strict: bool) -> anyhow::Result<()> {
     let mut cmd = Command::new("cargo");
-    let cmd = cmd.arg("clippy").arg("--workspace").arg("--all-features");
+    let mut cmd = cmd.arg("clippy").arg("--workspace").arg("--all-features");
+    if strict {
+        cmd = cmd.args(["--", "-D", "warnings"]);
+    }
 
     ui::print_cmd(cmd);
 

--- a/prep/src/cmd/format.rs
+++ b/prep/src/cmd/format.rs
@@ -8,9 +8,12 @@ use anyhow::{Context, ensure};
 use crate::ui;
 
 /// Format the workspace
-pub fn run() -> anyhow::Result<()> {
+pub fn run(check: bool) -> anyhow::Result<()> {
     let mut cmd = Command::new("cargo");
-    let cmd = cmd.arg("fmt").arg("--all");
+    let mut cmd = cmd.arg("fmt").arg("--all");
+    if check {
+        cmd = cmd.arg("--check");
+    }
 
     ui::print_cmd(cmd);
 

--- a/prep/src/cmd/mod.rs
+++ b/prep/src/cmd/mod.rs
@@ -1,5 +1,6 @@
 // Copyright 2026 the Prep Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+pub mod ci;
 pub mod clippy;
 pub mod format;

--- a/prep/src/main.rs
+++ b/prep/src/main.rs
@@ -19,10 +19,23 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Commands {
+    #[command()]
+    Ci {
+        #[arg(short, long)]
+        extended: bool,
+        #[arg(short, long)]
+        no_fail_fast: bool,
+    },
     #[command(alias = "clp")]
-    Clippy,
+    Clippy {
+        #[arg(short, long)]
+        strict: bool,
+    },
     #[command(alias = "fmt")]
-    Format,
+    Format {
+        #[arg(short, long)]
+        check: bool,
+    },
 }
 
 fn main() -> anyhow::Result<()> {
@@ -36,7 +49,11 @@ fn main() -> anyhow::Result<()> {
     };
 
     match command {
-        Commands::Clippy => cmd::clippy::run(),
-        Commands::Format => cmd::format::run(),
+        Commands::Ci {
+            extended,
+            no_fail_fast,
+        } => cmd::ci::run(extended, !no_fail_fast),
+        Commands::Clippy { strict } => cmd::clippy::run(strict),
+        Commands::Format { check } => cmd::format::run(check),
     }
 }

--- a/prep/src/ui/help.rs
+++ b/prep/src/ui/help.rs
@@ -3,42 +3,30 @@
 
 use clap::Command;
 use clap::builder::StyledStr;
-use clap::builder::styling::{Color, Style};
+
+use crate::ui;
 
 /// Sets our custom help messages.
 pub fn set(cmd: Command) -> Command {
     let cmd = cmd.override_help(root_msg());
 
-    cmd.mut_subcommands(|mut scmd| {
+    cmd.mut_subcommands(|scmd| {
         let name = scmd.get_name();
-        if name == "format" {
-            scmd = scmd.override_help(format_msg());
+        if name == "ci" {
+            scmd.override_help(ci_msg())
+        } else if name == "format" {
+            scmd.override_help(format_msg())
         } else if name == "clippy" {
-            scmd = scmd.override_help(clippy_msg());
+            scmd.override_help(clippy_msg())
         } else {
             panic!("Sub-command '{name}' help message is not implemented");
         }
-        scmd
     })
-}
-
-fn color(index: u8) -> Option<Color> {
-    Some(Color::Ansi256(index.into()))
-}
-
-/// Returns `(header, cmd_or_arg, optional)` styles.
-///
-/// These correspond to `(green, cyan, blue)`.
-fn styles() -> (Style, Style, Style) {
-    let g = Style::new().fg_color(color(10)); // Green
-    let c = Style::new().fg_color(color(14)); // Cyan
-    let b = Style::new().fg_color(color(39)); // Blue
-    (g, c, b)
 }
 
 /// Returns the main help message.
 pub fn root_msg() -> StyledStr {
-    let (gb, cb, bb) = styles();
+    let (gb, cb, bb) = ui::styles();
     let help = format!(
         "\
 Prepare Rust projects for greatness.
@@ -46,22 +34,45 @@ Prepare Rust projects for greatness.
 {gb}Usage:{gb:#} {cb}prep{cb:#} {bb}[command] [options]{bb:#}
 
 {gb}Commands:{gb:#}
-  {cb}clp  clippy    {cb:#}Clippy analysis
-  {cb}fmt  format    {cb:#}Format files
-  {cb}     help      {cb:#}Print help
+  {cb}ci                  {cb:#}Verify for CI
+  {cb}clippy         clp  {cb:#}Analyze with Clippy
+  {cb}format         fmt  {cb:#}Format files
+  {cb}help                {cb:#}Print help
 
 {gb}Options:{gb:#}
-  {cb}-h  --help     {cb:#}Print help
-  {cb}-V  --version  {cb:#}Print version
+  {cb}--help          -h  {cb:#}Print a help message for the provided command.
+  {cb}--version       -V  {cb:#}Print version information.
 "
     );
 
     StyledStr::from(help)
 }
 
+/// Returns the `ci` help message.
+fn ci_msg() -> StyledStr {
+    let (gb, cb, bb) = ui::styles();
+
+    let help = format!(
+        "\
+Verify the Rust workspace for CI.
+
+{gb}Usage:{gb:#} {cb}prep ci{cb:#} {bb}[options]{bb:#}
+
+{gb}Options:{gb:#}
+  {cb}--extended      -e  {cb:#}Run the extended verification suite.
+  ····                    ······Good idea for actual CI, rarely useful for local prep.
+  {cb}--no-fail-fast  -n  {cb:#}Keep going when encountering an error.
+  {cb}--help          -h  {cb:#}Print this help message.
+"
+    )
+    .replace("·", "");
+
+    StyledStr::from(help)
+}
+
 /// Returns the `format` help message.
 fn format_msg() -> StyledStr {
-    let (gb, cb, bb) = styles();
+    let (gb, cb, bb) = ui::styles();
 
     let help = format!(
         "\
@@ -71,7 +82,8 @@ Format the Rust workspace with rustfmt.
 ····      ······ {cb}prep format{cb:#} {bb}[options]{bb:#}
 
 {gb}Options:{gb:#}
-  {cb}-h  --help     {cb:#}Print help
+  {cb}--check         -c  {cb:#}Verify that the workspace is already formatted.
+  {cb}--help          -h  {cb:#}Print this help message.
 "
     )
     .replace("·", "");
@@ -81,7 +93,7 @@ Format the Rust workspace with rustfmt.
 
 /// Returns the `clippy` help message.
 fn clippy_msg() -> StyledStr {
-    let (gb, cb, bb) = styles();
+    let (gb, cb, bb) = ui::styles();
     let help = format!(
         "\
 Analyze the Rust workspace with Clippy.
@@ -90,7 +102,8 @@ Analyze the Rust workspace with Clippy.
 ····      ······ {cb}prep clippy{cb:#} {bb}[options]{bb:#}
 
 {gb}Options:{gb:#}
-  {cb}-h  --help     {cb:#}Print help
+  {cb}--strict        -s  {cb:#}Treat warnings as errors.
+  {cb}--help          -h  {cb:#}Print this help message.
 "
     )
     .replace("·", "");

--- a/prep/src/ui/mod.rs
+++ b/prep/src/ui/mod.rs
@@ -6,15 +6,44 @@ pub mod help;
 use std::ffi::OsStr;
 use std::process::Command;
 
+use clap::builder::StyledStr;
+use clap::builder::styling::{Color, Style};
+
 /// Prints the binary name and its arguments to stderr.
 pub fn print_cmd(cmd: &Command) {
     let bin = cmd.get_program();
     let args = cmd.get_args().collect::<Vec<_>>().join(OsStr::new(" "));
 
-    eprintln!("     Running `{} {}`", bin.display(), args.display());
+    let (g, _, _) = styles();
+
+    let msg = format!(
+        "     {g}Running{g:#} `{} {}`",
+        bin.display(),
+        args.display()
+    );
+    let msg = StyledStr::from(msg);
+
+    eprintln!("{}", msg.ansi());
 }
 
+/// Prints the main help message.
 pub fn print_help() {
     // TODO: Don't print ANSI codes when not supported by the environment.
     eprint!("{}", help::root_msg().ansi());
+}
+
+/// Returns the corresponding ANSI 256-bit color.
+pub fn color(index: u8) -> Option<Color> {
+    Some(Color::Ansi256(index.into()))
+}
+
+/// Returns `(header, cmd_or_arg, optional)` styles.
+///
+/// These correspond to `(green, cyan, blue)`.
+pub fn styles() -> (Style, Style, Style) {
+    // TODO: Verify that especially the green color matches Cargo on non-Windows terminals.
+    let g = Style::new().fg_color(color(10)); // Green
+    let c = Style::new().fg_color(color(14)); // Cyan
+    let b = Style::new().fg_color(color(39)); // Blue
+    (g, c, b)
 }


### PR DESCRIPTION
The `prep ci` command will run `format` and `clippy` in strict verification mode.

It also has a `--no-fail-fast` mode.