### PR TITLE
Improve tool management.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * `tools` command for tool management. ([#27] by [@xStrom])
 * Automatic installation of tools from source via `cargo`.
   Now implemented for `ripgrep`. ([#28] by [@xStrom])
+* Automatic Rustfmt and Clippy installation via `rustup`. ([#29] by [@xStrom])
 * `--strict` option to `clippy`, `copyright`, and `format` commands to use locked tool versions. ([#27] by [@xStrom])
 
 ### Changed
@@ -46,6 +47,7 @@
 [#24]: https://github.com/Nevermore/prep/pull/24
 [#27]: https://github.com/Nevermore/prep/pull/27
 [#28]: https://github.com/Nevermore/prep/pull/28
+[#29]: https://github.com/Nevermore/prep/pull/29
 
 [Unreleased]: https://github.com/Nevermore/prep/compare/v0.2.0...HEAD
 [0.2.0]: https://github.com/Nevermore/prep/compare/v0.1.0...v0.2.0

--- a/prep/src/cmd/ci.rs
+++ b/prep/src/cmd/ci.rs
@@ -1,6 +1,8 @@
 // Copyright 2026 the Prep Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+use anyhow::Result;
+
 use crate::cmd::{CargoTargets, clippy, copyright, format};
 use crate::session::Session;
 
@@ -9,9 +11,9 @@ use crate::session::Session;
 /// Can be ran in `extended` mode for more thorough checks.
 ///
 /// Set `fail_fast` to `false` to run the checks to the end regardless of failure.
-pub fn run(session: &mut Session, extended: bool, fail_fast: bool) -> anyhow::Result<()> {
+pub fn run(session: &mut Session, extended: bool, fail_fast: bool) -> Result<()> {
     let mut errs: Vec<anyhow::Error> = Vec::new();
-    let mut step = |f: &mut dyn FnMut() -> anyhow::Result<()>| -> anyhow::Result<()> {
+    let mut step = |f: &mut dyn FnMut() -> Result<()>| -> Result<()> {
         if let Err(e) = f() {
             if fail_fast {
                 return Err(e);

--- a/prep/src/cmd/clippy.rs
+++ b/prep/src/cmd/clippy.rs
@@ -1,44 +1,83 @@
 // Copyright 2026 the Prep Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-use anyhow::{Context, ensure};
+use anyhow::{Context, Result, bail, ensure};
+use semver::{Op, VersionReq};
 
 use crate::cmd::CargoTargets;
 use crate::session::Session;
-use crate::tools::cargo::{Cargo, CargoDeps};
+use crate::tools::cargo::CargoDeps;
+use crate::tools::clippy::{Clippy, ClippyDeps};
 use crate::ui;
 
 /// Runs Clippy analysis on the given `targets`.
 ///
 /// In `strict` mode warnings are treated as errors and Cargo version is locked.
-pub fn run(session: &mut Session, strict: bool, targets: CargoTargets) -> anyhow::Result<()> {
-    let mut cmd = if strict {
+pub fn run(session: &mut Session, strict: bool, targets: CargoTargets) -> Result<()> {
+    let rust_components = vec!["clippy".into()];
+    let clippy = if strict {
         let tools_cfg = session.config().tools();
         let rustup_ver_req = tools_cfg.rustup().clone();
-        let ver_req = tools_cfg.rust().clone();
+        let cargo_ver_req = tools_cfg.rust().clone();
         let toolset = session.toolset();
-        let deps = CargoDeps::new(rustup_ver_req);
-        toolset.get::<Cargo>(&deps, &ver_req)?
+        let cargo_deps = CargoDeps::new(rustup_ver_req, rust_components);
+        let ver_req = derive_version(&cargo_ver_req)?;
+        let deps = ClippyDeps::new(cargo_deps, cargo_ver_req);
+        toolset.get::<Clippy>(&deps, &ver_req)?
     } else {
         let toolset = session.toolset();
-        let deps = CargoDeps::new(None);
-        toolset.get::<Cargo>(&deps, None)?
+        let cargo_deps = CargoDeps::new(None, rust_components);
+        let deps = ClippyDeps::new(cargo_deps, None);
+        toolset.get::<Clippy>(&deps, None)?
     };
-    let mut cmd = cmd
-        .current_dir(session.root_dir())
-        .arg("clippy")
-        .arg("--locked")
+
+    let mut cmd = clippy.cmd();
+    cmd.arg("--locked")
         .arg("--workspace")
         .args(targets.as_args())
         .arg("--all-features");
     if strict {
-        cmd = cmd.args(["--", "-D", "warnings"]);
+        cmd.args(["--", "-D", "warnings"]);
     }
 
-    ui::print_cmd(cmd);
+    ui::print_cmd(&cmd);
 
     let status = cmd.status().context("failed to run cargo clippy")?;
     ensure!(status.success(), "cargo clippy failed: {status}");
 
     Ok(())
+}
+
+/// Derives the clippy version from the Rust toolchain version.
+// NOTE: When we move to Rust toolchain names instead, the Clippy version could probably be any.
+//       That is because if we only use a non-default clippy version with a single toolchain version
+//       then there is no risk of getting an incorrect version back from the cache.
+//       Clippy, by design, can be only called by the primary toolchain. So this would work fine.
+fn derive_version(rust_ver_req: &VersionReq) -> Result<VersionReq> {
+    if rust_ver_req.comparators.len() != 1 {
+        bail!(
+            "Only simple `=MAJOR.MINOR` version requirements are supported for the Rust toolchain, got: {}",
+            rust_ver_req
+        );
+    }
+    let ver_req_comp = rust_ver_req.comparators.first().unwrap();
+    if ver_req_comp.op != Op::Exact
+        || ver_req_comp.patch.is_some()
+        || ver_req_comp.minor.is_none()
+        || !ver_req_comp.pre.is_empty()
+    {
+        bail!(
+            "Only simple `=MAJOR.MINOR` version requirements are supported for the Rust toolchain, got: {}",
+            ver_req_comp
+        );
+    }
+
+    let clippy_ver_req = VersionReq::parse(&format!(
+        "=0.{}.{}",
+        ver_req_comp.major,
+        ver_req_comp.minor.unwrap()
+    ))
+    .context("failed to parse clippy version requirement")?;
+
+    Ok(clippy_ver_req)
 }

--- a/prep/src/cmd/format.rs
+++ b/prep/src/cmd/format.rs
@@ -1,34 +1,42 @@
 // Copyright 2026 the Prep Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-use anyhow::{Context, ensure};
+use anyhow::{Context, Result, ensure};
+use semver::VersionReq;
 
 use crate::session::Session;
-use crate::tools::cargo::{Cargo, CargoDeps};
+use crate::tools::cargo::CargoDeps;
+use crate::tools::rustfmt::{Rustfmt, RustfmtDeps};
 use crate::ui;
 
 /// Format the workspace.
 ///
 /// In `strict` mode Cargo version is locked.
-pub fn run(session: &mut Session, strict: bool, check: bool) -> anyhow::Result<()> {
-    let mut cmd = if strict {
+pub fn run(session: &mut Session, strict: bool, check: bool) -> Result<()> {
+    let rust_components = vec!["rustfmt".into()];
+    let rustfmt = if strict {
         let tools_cfg = session.config().tools();
         let rustup_ver_req = tools_cfg.rustup().clone();
-        let ver_req = tools_cfg.rust().clone();
+        let cargo_ver_req = tools_cfg.rust().clone();
         let toolset = session.toolset();
-        let deps = CargoDeps::new(rustup_ver_req);
-        toolset.get::<Cargo>(&deps, &ver_req)?
+        let cargo_deps = CargoDeps::new(rustup_ver_req, rust_components);
+        let deps = RustfmtDeps::new(cargo_deps, cargo_ver_req);
+        let ver_req = VersionReq::parse("=1.8.0-stable")?; // TODO: Replace with a custom 'Any' (NOT None!)
+        toolset.get::<Rustfmt>(&deps, &ver_req)?
     } else {
         let toolset = session.toolset();
-        let deps = CargoDeps::new(None);
-        toolset.get::<Cargo>(&deps, None)?
+        let cargo_deps = CargoDeps::new(None, rust_components);
+        let deps = RustfmtDeps::new(cargo_deps, None);
+        toolset.get::<Rustfmt>(&deps, None)?
     };
-    let mut cmd = cmd.current_dir(session.root_dir()).arg("fmt").arg("--all");
+
+    let mut cmd = rustfmt.cmd();
+    cmd.arg("--all");
     if check {
-        cmd = cmd.arg("--check");
+        cmd.arg("--check");
     }
 
-    ui::print_cmd(cmd);
+    ui::print_cmd(&cmd);
 
     let status = cmd.status().context("failed to run cargo fmt")?;
     ensure!(status.success(), "cargo fmt failed: {status}");

--- a/prep/src/cmd/init.rs
+++ b/prep/src/cmd/init.rs
@@ -1,11 +1,13 @@
 // Copyright 2026 the Prep Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+use anyhow::Result;
+
 use crate::session::Session;
 use crate::ui;
 
 /// Initialize the prep configuration
-pub fn run(session: &Session, force: bool) -> anyhow::Result<()> {
+pub fn run(session: &Session, force: bool) -> Result<()> {
     if !force && session.config_path().exists() {
         ui::print_err(
             "Prep configuration already exists, aborting.\n\

--- a/prep/src/config.rs
+++ b/prep/src/config.rs
@@ -26,6 +26,8 @@ pub struct Project {
     license: String,
 }
 
+// TODO: Refactor these away from VersionReq, as Rust toolchain specification is needed instead.
+
 /// Tools configuration.
 #[derive(Serialize, Deserialize)]
 pub struct Tools {

--- a/prep/src/environment.rs
+++ b/prep/src/environment.rs
@@ -1,0 +1,48 @@
+// Copyright 2026 the Prep Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use std::collections::BTreeMap;
+use std::process::Command;
+
+/// Set of environment variables for running a binary.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct Environment {
+    vars: BTreeMap<String, String>,
+}
+
+impl Environment {
+    /// Creates a new default set of environment variables.
+    pub fn new() -> Self {
+        let mut vars = BTreeMap::new();
+        vars.insert("RUSTUP_AUTO_INSTALL".into(), "0".into());
+        Self { vars }
+    }
+
+    /// Sets a specific Rust toolchain.
+    ///
+    /// The `toolchain_name` must follow the [toolchain name specification].
+    ///
+    /// [toolchain name specification]: https://rust-lang.github.io/rustup/concepts/toolchains.html
+    pub fn rust(mut self, toolchain_name: Option<String>) -> Self {
+        const KEY: &str = "RUSTUP_TOOLCHAIN";
+        if let Some(toolchain_name) = toolchain_name {
+            self.vars.insert(KEY.into(), toolchain_name);
+        } else {
+            self.vars.remove(KEY);
+        }
+        self
+    }
+
+    /// Returns the underlying map.
+    pub fn vars(&self) -> &BTreeMap<String, String> {
+        &self.vars
+    }
+
+    /// Apply the environment variables to the command.
+    pub fn apply<'a>(&self, mut cmd: &'a mut Command) -> &'a mut Command {
+        for (k, v) in &self.vars {
+            cmd = cmd.env(k, v);
+        }
+        cmd
+    }
+}

--- a/prep/src/main.rs
+++ b/prep/src/main.rs
@@ -5,12 +5,14 @@
 
 mod cmd;
 mod config;
+mod environment;
 mod host;
 mod session;
 mod tools;
 mod toolset;
 mod ui;
 
+use anyhow::Result;
 use clap::{CommandFactory, FromArgMatches, Parser, Subcommand};
 
 use ui::help;
@@ -71,7 +73,7 @@ enum ToolsCommands {
     List,
 }
 
-fn main() -> anyhow::Result<()> {
+fn main() -> Result<()> {
     let ccmd = help::set(Cli::command());
     let matches = ccmd.get_matches();
     let cli = Cli::from_arg_matches(&matches).unwrap();

--- a/prep/src/tools/clippy.rs
+++ b/prep/src/tools/clippy.rs
@@ -1,0 +1,80 @@
+// Copyright 2026 the Prep Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use anyhow::{Context, Result, bail};
+use semver::{Version, VersionReq};
+
+use crate::tools::cargo::{Cargo, CargoDeps};
+use crate::tools::{BinCtx, Tool};
+use crate::toolset::Toolset;
+
+/// Clippy from the Rust toolchain.
+pub struct Clippy;
+
+/// Clippy dependencies.
+#[derive(Default)]
+pub struct ClippyDeps {
+    /// Cargo dependencies.
+    cargo_deps: CargoDeps,
+    /// Cargo version requirement.
+    cargo_ver_req: Option<VersionReq>,
+}
+
+impl ClippyDeps {
+    /// Creates new Clippy dependency requirements.
+    ///
+    /// `None` means that the default version will be used.
+    pub fn new(cargo_deps: CargoDeps, cargo_ver_req: impl Into<Option<VersionReq>>) -> Self {
+        Self {
+            cargo_deps,
+            cargo_ver_req: cargo_ver_req.into(),
+        }
+    }
+}
+
+impl Tool for Clippy {
+    type Deps = ClippyDeps;
+
+    const NAME: &str = "clippy";
+    const BIN: &str = "cargo";
+    const MANAGED: bool = false;
+
+    fn default_binctx(toolset: &mut Toolset, deps: &Self::Deps) -> Result<BinCtx> {
+        let cargo = toolset.get::<Cargo>(&deps.cargo_deps, deps.cargo_ver_req.as_ref())?;
+        let binctx = cargo.args(vec!["clippy".into()]);
+        Ok(binctx)
+    }
+
+    fn set_up(
+        toolset: &mut Toolset,
+        deps: &Self::Deps,
+        ver_req: &VersionReq,
+    ) -> Result<(BinCtx, Version)> {
+        // Directly calling set_up will bypass the toolset cache
+        // and allows us to set up the potentially missing components.
+        let cargo_ver_req = deps.cargo_ver_req.as_ref().unwrap_or_else(|| {
+            panic!(
+                "{} set up requires a specific {} version dependency",
+                Self::NAME,
+                Cargo::NAME
+            )
+        });
+        let (cargo, _) = Cargo::set_up(toolset, &deps.cargo_deps, cargo_ver_req)
+            .context(format!("failed to set up {}", Cargo::NAME))?;
+
+        let binctx = cargo.args(vec!["clippy".into()]);
+
+        // Verify that it actually works.
+        let Some(version) = toolset
+            .verify::<Self>(&binctx, ver_req)
+            .context(format!("failed to verify {}", Self::NAME))?
+        else {
+            bail!(
+                "'{}' was just installed but now was no longer found",
+                binctx.path().display()
+            );
+        };
+
+        Ok((binctx, version))
+    }
+}

--- a/prep/src/tools/mod.rs
+++ b/prep/src/tools/mod.rs
@@ -2,7 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 pub mod cargo;
+pub mod clippy;
 pub mod ripgrep;
+pub mod rustfmt;
 pub mod rustup;
 
 use std::io::ErrorKind;
@@ -13,19 +15,31 @@ use anyhow::{Context, Result, ensure};
 use regex::Regex;
 use semver::{Version, VersionReq};
 
+use crate::environment::Environment;
 use crate::toolset::Toolset;
 use crate::ui;
 
 /// Generic Prep tool code.
 pub trait Tool: Sized + 'static {
-    type Deps;
+    /// The type describing the dependencies of this tool.
+    type Deps: Default;
 
+    /// The name of the tool, used for both display and to identify the cargo package.
     const NAME: &str;
+    /// The binary executable name.
     const BIN: &str;
+    /// Whether the tool installation is managed by toolset.
+    const MANAGED: bool;
+
+    /// Returns the default binary context for this tool
+    #[expect(unused_variables, reason = "default impl doesn't use deps")]
+    fn default_binctx(toolset: &mut Toolset, deps: &Self::Deps) -> Result<BinCtx> {
+        Ok(toolset.binctx(Self::BIN.into()))
+    }
 
     /// Sets up a version of the tool that meets the given `ver_req`.
     ///
-    /// Returns the specific version and the path to the binary.
+    /// Returns the specific version and the binary context.
     ///
     /// Implementations must call [`toolset.verify`] to ensure the setup succeeded.
     ///
@@ -34,16 +48,16 @@ pub trait Tool: Sized + 'static {
         toolset: &mut Toolset,
         deps: &Self::Deps,
         ver_req: &VersionReq,
-    ) -> Result<(Version, PathBuf)>;
+    ) -> Result<(BinCtx, Version)>;
 
-    /// Returns the [`Version`] of the binary at the given `path`.
+    /// Returns the [`Version`] of the given binary context.
     ///
-    /// Returns `None` if the given `path` doesn't exist.
-    fn extract_version(path: &Path) -> Result<Option<Version>> {
-        let mut cmd = Command::new(path);
-        let cmd = cmd.arg("-V");
+    /// Returns `None` if the given binary context's path doesn't exist.
+    fn extract_version(binctx: &BinCtx) -> Result<Option<Version>> {
+        let mut cmd = binctx.cmd();
+        cmd.arg("--version");
 
-        ui::print_cmd(cmd);
+        ui::print_cmd(&cmd);
 
         let output = cmd.output();
         if output
@@ -52,20 +66,31 @@ pub trait Tool: Sized + 'static {
         {
             return Ok(None);
         }
-        let output = output.context(format!("failed to run '{}'", path.display()))?;
+        let output = output.context(format!("failed to run '{}'", binctx.path().display()))?;
+        if output.status.code().is_some_and(|code| code == 1) {
+            let error = String::from_utf8(output.stderr).context(format!(
+                "'{}' output not valid UTF-8",
+                binctx.path().display()
+            ))?;
+            if error.contains("error") && error.contains("is not installed") {
+                return Ok(None);
+            }
+        }
         ensure!(
             output.status.success(),
             "'{}' failed: {}",
-            path.display(),
+            binctx.path().display(),
             output.status
         );
 
-        let version = String::from_utf8(output.stdout)
-            .context(format!("'{}' output not valid UTF-8", path.display()))?;
+        let version = String::from_utf8(output.stdout).context(format!(
+            "'{}' output not valid UTF-8",
+            binctx.path().display()
+        ))?;
         let version = version
             .lines()
             .next()
-            .context(format!("'{}' output was empty", path.display()))?;
+            .context(format!("'{}' output was empty", binctx.path().display()))?;
 
         let re = Regex::new(r"^\S+\s+(\d+\.\d+\.\d+[^\s]*)")
             .expect("Version extraction regex was incorrect");
@@ -74,14 +99,55 @@ pub trait Tool: Sized + 'static {
             .and_then(|c| c.get(1).map(|m| m.as_str()))
             .context(format!(
                 "'{}' output didn't contain version",
-                path.display()
+                binctx.path().display()
             ))?;
 
         let version = Version::parse(version).context(format!(
             "failed to parse '{}' version '{version}'",
-            path.display()
+            binctx.path().display()
         ))?;
 
         Ok(Some(version))
+    }
+}
+
+/// Binary executable context.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct BinCtx {
+    path: PathBuf,
+    working_dir: PathBuf,
+    environment: Environment,
+    args: Vec<String>,
+}
+
+impl BinCtx {
+    /// Creates a new binary executable context.
+    pub fn new(path: PathBuf, working_dir: PathBuf, environment: Environment) -> Self {
+        Self {
+            path,
+            working_dir,
+            environment,
+            args: Vec::new(),
+        }
+    }
+
+    /// Returns the binary context with the given base arguments.
+    pub fn args(mut self, args: Vec<String>) -> Self {
+        self.args = args;
+        self
+    }
+
+    /// Creates a [`Command`] based on this binary context.
+    pub fn cmd(&self) -> Command {
+        let mut cmd = Command::new(&self.path);
+        cmd.current_dir(&self.working_dir);
+        self.environment.apply(&mut cmd);
+        cmd.args(&self.args);
+        cmd
+    }
+
+    /// Returns the underlying binary path.
+    pub fn path(&self) -> &Path {
+        &self.path
     }
 }

--- a/prep/src/tools/rustfmt.rs
+++ b/prep/src/tools/rustfmt.rs
@@ -1,0 +1,80 @@
+// Copyright 2026 the Prep Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use anyhow::{Context, Result, bail};
+use semver::{Version, VersionReq};
+
+use crate::tools::cargo::{Cargo, CargoDeps};
+use crate::tools::{BinCtx, Tool};
+use crate::toolset::Toolset;
+
+/// Rustfmt from the Rust toolchain.
+pub struct Rustfmt;
+
+/// Rustfmt dependencies.
+#[derive(Default)]
+pub struct RustfmtDeps {
+    /// Cargo dependencies.
+    cargo_deps: CargoDeps,
+    /// Cargo version requirement.
+    cargo_ver_req: Option<VersionReq>,
+}
+
+impl RustfmtDeps {
+    /// Creates new Rustfmt dependency requirements.
+    ///
+    /// `None` means that the default version will be used.
+    pub fn new(cargo_deps: CargoDeps, cargo_ver_req: impl Into<Option<VersionReq>>) -> Self {
+        Self {
+            cargo_deps,
+            cargo_ver_req: cargo_ver_req.into(),
+        }
+    }
+}
+
+impl Tool for Rustfmt {
+    type Deps = RustfmtDeps;
+
+    const NAME: &str = "rustfmt";
+    const BIN: &str = "cargo";
+    const MANAGED: bool = false;
+
+    fn default_binctx(toolset: &mut Toolset, deps: &Self::Deps) -> Result<BinCtx> {
+        let cargo = toolset.get::<Cargo>(&deps.cargo_deps, deps.cargo_ver_req.as_ref())?;
+        let binctx = cargo.args(vec!["fmt".into()]);
+        Ok(binctx)
+    }
+
+    fn set_up(
+        toolset: &mut Toolset,
+        deps: &Self::Deps,
+        ver_req: &VersionReq,
+    ) -> Result<(BinCtx, Version)> {
+        // Directly calling set_up will bypass the toolset cache
+        // and allows us to set up the potentially missing components.
+        let cargo_ver_req = deps.cargo_ver_req.as_ref().unwrap_or_else(|| {
+            panic!(
+                "{} set up requires a specific {} version dependency",
+                Self::NAME,
+                Cargo::NAME
+            )
+        });
+        let (cargo, _) = Cargo::set_up(toolset, &deps.cargo_deps, cargo_ver_req)
+            .context(format!("failed to set up {}", Cargo::NAME))?;
+
+        let binctx = cargo.args(vec!["fmt".into()]);
+
+        // Verify that it actually works.
+        let Some(version) = toolset
+            .verify::<Self>(&binctx, ver_req)
+            .context(format!("failed to verify {}", Self::NAME))?
+        else {
+            bail!(
+                "'{}' was just installed but now was no longer found",
+                binctx.path().display()
+            );
+        };
+
+        Ok((binctx, version))
+    }
+}

--- a/prep/src/ui/mod.rs
+++ b/prep/src/ui/mod.rs
@@ -22,12 +22,18 @@ pub fn print_lines(header: &str, lines: &str) {
 
 /// Prints the binary name and its arguments to stderr.
 pub fn print_cmd(cmd: &Command) {
+    let envs = cmd
+        .get_envs()
+        .map(|(k, v)| format!("{}={}", k.display(), v.unwrap_or_default().display()))
+        .collect::<Vec<_>>()
+        .join(" ");
     let bin = cmd.get_program();
     let args = cmd.get_args().collect::<Vec<_>>().join(OsStr::new(" "));
 
     let h = style::HEADER;
     eprintln!(
-        "     {h}Running{h:#} `{} {}`",
+        "     {h}Running{h:#} `{} {} {}`",
+        envs,
         bin.display(),
         args.display()
     );


### PR DESCRIPTION
Heavily reworked how tool management is done. This is to allow better handling of Clippy and Rustfmt. Especially as for Rustfmt we must call it via Cargo and can not call it directly.

Rust toolchain version selection is now done via the `RUSTUP_TOOLCHAIN` environment variable.